### PR TITLE
Use apt-get for ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM debian
 
-RUN apt-get update && apt-get install -y git python-pip openssh-client python-dev ruby curl
+# For Ansible v2, from https://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-apt-debian
+RUN echo 'deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main' >> /etc/apt/sources.list
+
+RUN apt-get update
+
+# Use --force-yes because the ansible package cannot be authenticated
+RUN apt-get install -y --force-yes git python-pip openssh-client python-dev ruby curl ansible
 
 ENV HOME /root
 RUN ssh-keygen -f /root/.ssh/id_rsa -q -N ""
 
-RUN pip install ansible markupsafe
-
-RUN pip install dopy boto linode-python pyrax
-
+RUN pip install markupsafe dopy boto linode-python pyrax
 
 WORKDIR /root
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ After it's finished, streisand will try and xdg-open the generated documentation
 ```
 docker cp streisand:/root/streisand/generated-docs/streisand.html streisand.html
 ```
+
+Note that the name of the html file will be the same as the name you gave in the server setup. If you name your server `streisand-demo`, then the file will be `streisand-demo.html`.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ git clone https://github.com/gdoteof/docker-streisand.git
 
 cd docker-streisand
 
-sudo docker build -t streisand .
-sudo docker run -i -t --name streisand streisand
+docker build -t streisand .
+docker run -i -t --name streisand streisand
 ```
 
 This will prompt you to enter your API credentials
@@ -34,5 +34,5 @@ This will prompt you to enter your API credentials
 After it's finished, streisand will try and xdg-open the generated documentation (which will fail).  You should copy it to the host with
 
 ```
-sudo docker cp streisand:/root/streisand/generated-docs/streisand.html streisand.html
+docker cp streisand:/root/streisand/generated-docs/streisand.html streisand.html
 ```


### PR DESCRIPTION
This fixes https://github.com/gdoteof/docker-streisand/issues/5

This PR also updates the README to remove the need for `sudo` and clarify the name of the output file.